### PR TITLE
crashfix: clear setted textures on new frame

### DIFF
--- a/d912pxy/d912pxy_iframe.cpp
+++ b/d912pxy/d912pxy_iframe.cpp
@@ -393,6 +393,8 @@ void d912pxy_iframe::Start()
 
 	cuPrimType = D3DPT_TRIANGLELIST;
 
+	d912pxy_s.render.state.tex.ClearActiveTextures();
+
 	d912pxy_query_occlusion::OnIFrameStart();
 
 }
@@ -546,6 +548,12 @@ void d912pxy_iframe::StateSafeFlush(UINT fullFlush)
 		if (refSurf[i])
 			refSurf[i]->ThreadRef(1);
 	}
+
+	UINT textureTransfer[PXY_INNER_MAX_TEXTURE_STAGES - 1];
+	for (int i = 0; i != PXY_INNER_MAX_TEXTURE_STAGES - 1; ++i)
+	{
+		textureTransfer[i] = d912pxy_s.render.state.tex.GetTexStage(i);
+	}
 		
 	End();
 	if (fullFlush)
@@ -584,6 +592,14 @@ void d912pxy_iframe::StateSafeFlush(UINT fullFlush)
 	//megai2: rebind scissor 
 	SetScissors(&transSR);
 	SetViewport(&transVW);	
+
+	//reset textures back in place
+	//WARN: GPU crash here if api stream will have 3 sequental StateSafeFlushes(0) 
+	//and non-cleared from stage, deleted, but used in shader texture
+	for (int i = 0; i != PXY_INNER_MAX_TEXTURE_STAGES - 1; ++i)
+	{
+		d912pxy_s.render.state.tex.SetTexture(i, textureTransfer[i]);
+	}
 	
 	ForceStateRebind();	
 }

--- a/d912pxy/d912pxy_surface.cpp
+++ b/d912pxy/d912pxy_surface.cpp
@@ -694,6 +694,17 @@ void d912pxy_surface::FreeObjAndSlot()
 {
 	if (m_res)
 	{
+#ifdef _DEBUG
+		if (dheapId > 0)
+		{
+			for (int i = 0; i != 31; ++i)
+				if (d912pxy_s.render.state.tex.GetTexStage(i) == dheapId)
+				{
+					LOG_ERR_DTDM("dheapId %u is active in tex stage %u at deletion time", dheapId, i);
+				}
+		}
+#endif
+
 		m_res->Release();
 		m_res = NULL;
 

--- a/d912pxy/d912pxy_texture_state.cpp
+++ b/d912pxy/d912pxy_texture_state.cpp
@@ -185,6 +185,15 @@ void d912pxy_texture_state::AddDirtyFlag(DWORD val)
 	current.dirty |= val;
 }
 
+void d912pxy_texture_state::ClearActiveTextures()
+{
+	//stage 31 is hardcoded atest value, not actual texture stage
+	for (int i = 0; i != PXY_INNER_MAX_TEXTURE_STAGES - 1; ++i)
+	{
+		SetTexture(i, 0);
+	}
+}
+
 UINT d912pxy_texture_state::LookupSamplerId(UINT stage)
 {
 	UINT ret = (UINT32)splLookup->PointAt32(&trimmedSpl[stage]);

--- a/d912pxy/d912pxy_texture_state.h
+++ b/d912pxy/d912pxy_texture_state.h
@@ -66,6 +66,8 @@ public:
 
 	d912pxy_device_texture_state* GetCurrent() { return &current; };
 
+	void ClearActiveTextures();
+
 private:
 	UINT LookupSamplerId(UINT stage);
 


### PR DESCRIPTION
If texture is left setted up after frame end, but deleted and used in shader, gpu crash will occur.